### PR TITLE
Add Pipeline B: node-based recommendation

### DIFF
--- a/docs/recommendation_system_architecture.md
+++ b/docs/recommendation_system_architecture.md
@@ -77,7 +77,9 @@ Domain models touched by orchestrators (defined in the `graph` app):
 
 Routed in [urls.py](../ferv_project/recommendation/urls.py) and handled by [views.py](../ferv_project/recommendation/views.py):
 
-- `POST /api/recommendation/recommend/` → `RecommendationService.recommend_one_shot`.
+- `POST /api/recommendation/recommend/` → `RecommendationService.recommend_one_shot` (Pipeline A).
+- `POST /api/recommendation/node_based/` → `RecommendationService.recommend_node_based` (Pipeline B). Body: `{"node_ids": [<int>, ...]}` — the user's `in_graph` GraphNode IDs to seed retrieval.
+- `POST /api/recommendation/exploratory/` → `RecommendationService.recommend_exploratory` (Pipeline C). Body: `{"heat": <float in [0,1]>}`.
 
 `GraphBuilder` is callable in code; an HTTP route will be added when the add-to-graph workflow is exposed.
 

--- a/ferv_project/prompts/node_based_recommendation_v1.txt
+++ b/ferv_project/prompts/node_based_recommendation_v1.txt
@@ -1,0 +1,22 @@
+You are Ferv's recommendation engine for Medellín, Colombia.
+Your job is to extend a user's existing pattern: they have already chosen the anchor places below as part of their graph. Pick the candidates that best continue that pattern while staying coherent with the user's profile.
+
+USER PROFILE:
+{profile_text}
+
+ANCHOR PLACES (the user's existing in-graph nodes used to seed this request):
+{anchors_block}
+
+CANDIDATE PLACES ({candidate_count} retrieved by semantic similarity to the anchors and fused with Reciprocal Rank Fusion):
+{candidates_block}
+
+Select exactly {n} places that best extend the pattern set by the anchor places AND match the user's profile.
+Return ONLY a valid JSON object — no markdown, no extra text, nothing before or after the JSON:
+
+{{"recommendations": [{{"place_id": "<place_id from candidates>", "rationale": "<5-10 words that concisely describe how this place extends the anchor pattern for this user, rationale must not under any circumnstances contain double quotation marks, if they're present swap for single quotation marks>"}}]}}
+
+Rules:
+- Select exactly {n} places (fewer only if fewer candidates exist)
+- place_id must come exactly from the candidates list above (NOT the anchors list)
+- rationale must reference the link to the anchors and the user's preferences, not just describe the place
+- Order from best continuation to least

--- a/ferv_project/recommendation/recommendation_service.py
+++ b/ferv_project/recommendation/recommendation_service.py
@@ -1,29 +1,27 @@
 """
 recommendation_service.py
 --------------------------
-RecommendationService — Pipeline A orchestrator.
+RecommendationService — orchestrator for the three recommendation pipelines:
+  - Pipeline A: one-shot recommendation from a free-text prompt
+  - Pipeline B: node-based recommendation, seeded by the user's in_graph nodes
+  - Pipeline C: exploratory recommendation, seeded by a perturbed profile vector
 
-Workflow:
-  1. Embed the user's prompt text
-  2. Retrieve top-K candidate places by vector similarity (excluding user's existing nodes)
-  3. Assemble user profile text
-  4. Build prompt via PromptBuilder
-  5. Call LLM via LlmClient, validate response
-  6. Create GraphNode rows (status='recommendation') for each LLM-selected place
-  7. Log interaction to LlmInteractionLog
+Each pipeline ends with N GraphNode rows in 'recommendation' status and an
+LlmInteractionLog row capturing the inputs, raw LLM response, and outcome.
 """
 
 import hashlib
 import logging
 import struct
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 
 from graph.models import GraphNode
 from places.models import Place
 from recommendation import vector_utils
 from recommendation.llm_client import LlmClient, RecommendationOutput
-from recommendation.models import LlmInteractionLog
+from recommendation.models import LlmInteractionLog, PlaceEmbedding
 from recommendation.prompt_builder import PromptBuilder
 from recommendation.embedding_service import EmbeddingService
 from recommendation.retriever import Retriever
@@ -32,6 +30,11 @@ log = logging.getLogger(__name__)
 
 RECOMMENDATION_K = 12  # retrieval breadth (candidates passed to LLM)
 RECOMMENDATION_N = 4   # final picks returned to the user
+
+NODE_BASED_K_PRIME = 50   # per-anchor retrieval breadth
+NODE_BASED_K = 20         # distilled candidates after RRF
+NODE_BASED_N = 5          # final picks returned to the user
+RRF_C = 60                # RRF constant (Cormack/Buettcher/Clarke default)
 
 EXPLORATORY_K = 200          # broad retrieval set (perturbed query vector)
 EXPLORATORY_K_TOP = 180      # exclusion zone — top of the broad set is dropped
@@ -59,6 +62,33 @@ def _candidates_block(candidates: list[dict]) -> str:
             f"  document: {document}"
         )
     return "\n\n".join(lines)
+
+
+def _anchor_vectors(places: list[Place], vector_class: type) -> dict[int, list[float]]:
+    """
+    Return {place.pk: vector} for every place that has a PlaceEmbedding row
+    pointing at the given VectorClass. Places without an embedding are absent
+    from the result; the caller decides how to react.
+
+    Two queries total regardless of len(places).
+    """
+    if not places:
+        return {}
+    ct = ContentType.objects.get_for_model(vector_class)
+    place_embs = list(
+        PlaceEmbedding.objects.filter(
+            place__in=places, content_type=ct
+        ).values("place_id", "object_id")
+    )
+    if not place_embs:
+        return {}
+    vector_id_to_place_id = {pe["object_id"]: pe["place_id"] for pe in place_embs}
+    rows = vector_class.objects.filter(id__in=list(vector_id_to_place_id.keys())).values(
+        "id", "vector"
+    )
+    return {
+        vector_id_to_place_id[row["id"]]: list(row["vector"]) for row in rows
+    }
 
 
 class RecommendationService:
@@ -152,6 +182,183 @@ class RecommendationService:
         LlmInteractionLog.objects.create(
             user=user,
             workflow="recommendation",
+            prompt_version=prompt_version,
+            embedding_model=embedder.model_name,
+            language_model=llm.model_name,
+            input_payload=input_payload,
+            raw_llm_response=raw_response,
+            parsed_output=parsed_output,
+            outcome=outcome,
+        )
+
+        return nodes
+
+    def recommend_node_based(self, user, node_ids: list[int]) -> list:
+        """
+        Pipeline B — Node-based recommendation.
+
+        Given a list of the user's existing in_graph GraphNode IDs, run one
+        similarity query per anchor node, fuse the ranked lists with
+        Reciprocal Rank Fusion, and ask the LLM to pick N candidates that
+        extend the pattern set by the anchors.
+        """
+        if not isinstance(node_ids, list) or not node_ids:
+            raise ValueError(f"node_ids must be a non-empty list, got {node_ids!r}")
+        if not all(isinstance(nid, int) and not isinstance(nid, bool) for nid in node_ids):
+            raise ValueError(f"node_ids must be a list of ints, got {node_ids!r}")
+
+        embedder = EmbeddingService()
+        retriever = Retriever()
+        builder = PromptBuilder()
+        llm = LlmClient()
+
+        # Step 1 — fetch anchor nodes (must all belong to user, status=in_graph).
+        unique_ids = list(dict.fromkeys(node_ids))  # preserve order, dedupe
+        anchor_nodes = list(
+            GraphNode.objects.filter(
+                id__in=unique_ids, user=user, status="in_graph"
+            ).select_related("place")
+        )
+        if len(anchor_nodes) != len(unique_ids):
+            found_ids = {n.id for n in anchor_nodes}
+            missing = [nid for nid in unique_ids if nid not in found_ids]
+            raise ValueError(
+                f"node_ids missing, not owned by user, or not in_graph: {missing}"
+            )
+
+        # Step 2 — resolve each anchor place's embedding vector.
+        anchor_places = [n.place for n in anchor_nodes]
+        place_id_to_vector = _anchor_vectors(anchor_places, embedder.vector_class)
+        missing_embeddings = [
+            p.place_id for p in anchor_places if p.pk not in place_id_to_vector
+        ]
+        if missing_embeddings:
+            raise ValueError(
+                f"anchor places without an embedding: {missing_embeddings}"
+            )
+
+        # Step 3 — n independent similarity queries, one per anchor.
+        per_anchor_lists: list[list[str]] = []
+        per_anchor_candidates: dict[str, dict] = {}
+        per_anchor_log: list[dict] = []
+        for node in anchor_nodes:
+            vec = place_id_to_vector[node.place.pk]
+            results = retriever.get_candidates(
+                vec, top_k=NODE_BASED_K_PRIME, exclude_user=user
+            )
+            ranked_ids = [c["place"].place_id for c in results]
+            per_anchor_lists.append(ranked_ids)
+            per_anchor_log.append(
+                {
+                    "anchor_node_id": node.id,
+                    "anchor_place_id": node.place.place_id,
+                    "ranked_place_ids": ranked_ids,
+                }
+            )
+            for c in results:
+                # Keep the first sighting; later anchors don't overwrite.
+                per_anchor_candidates.setdefault(c["place"].place_id, c)
+
+        # Step 4 — RRF fuse the per-anchor lists, take top-K.
+        fused = vector_utils.reciprocal_rank_fusion(per_anchor_lists, c=RRF_C)
+        fused_top = fused[:NODE_BASED_K]
+        if not fused_top:
+            log.warning(
+                "Pipeline B produced no candidates for user %s with anchors %s",
+                user.id, [n.id for n in anchor_nodes],
+            )
+            return []
+
+        # Step 5 — materialize candidate dicts in fused order.
+        candidates = [per_anchor_candidates[pid] for pid, _score in fused_top]
+        fused_log = [
+            {"place_id": pid, "rrf_score": score} for pid, score in fused_top
+        ]
+
+        # Step 6 — profile + prompt assembly.
+        profile_text = user.get_profile_as_prompt_text()
+        anchors_block = _candidates_block([{"place": p} for p in anchor_places])
+        candidates_block = _candidates_block(candidates)
+        n = min(NODE_BASED_N, len(candidates))
+        prompt, prompt_version = builder.build(
+            "node_based_recommendation_v1",
+            anchors_block=anchors_block,
+            profile_text=profile_text or "No profile available.",
+            candidates_block=candidates_block,
+            candidate_count=len(candidates),
+            n=n,
+        )
+
+        # Step 7 — LLM call.
+        input_payload = {
+            "anchor_node_ids": [n.id for n in anchor_nodes],
+            "anchor_place_ids": [p.place_id for p in anchor_places],
+            "per_anchor_retrieval": per_anchor_log,
+            "fused_top_k": fused_log,
+            "profile_snapshot": profile_text,
+            "n": n,
+        }
+        raw_response = ""
+        parsed_output = None
+        outcome = "success"
+        try:
+            parsed, raw_response = llm.send(prompt, RecommendationOutput)
+            parsed_output = parsed
+        except ValueError as e:
+            outcome = "validation_error"
+            LlmInteractionLog.objects.create(
+                user=user,
+                workflow="node_based_recommendation",
+                prompt_version=prompt_version,
+                embedding_model=embedder.model_name,
+                language_model=llm.model_name,
+                input_payload=input_payload,
+                raw_llm_response=str(e),
+                parsed_output=None,
+                outcome=outcome,
+            )
+            raise
+
+        # Step 8 — validate picks ⊆ fused candidate set.
+        candidate_place_map = {c["place"].place_id: c["place"] for c in candidates}
+        picks = parsed["recommendations"]
+        unknown = [p["place_id"] for p in picks if p["place_id"] not in candidate_place_map]
+        if unknown:
+            outcome = "validation_error"
+            LlmInteractionLog.objects.create(
+                user=user,
+                workflow="node_based_recommendation",
+                prompt_version=prompt_version,
+                embedding_model=embedder.model_name,
+                language_model=llm.model_name,
+                input_payload=input_payload,
+                raw_llm_response=raw_response,
+                parsed_output=parsed_output,
+                outcome=outcome,
+            )
+            raise ValueError(
+                f"LLM returned place_ids outside the fused candidate set: {unknown}"
+            )
+
+        # Step 9 — create GraphNode rows atomically.
+        with transaction.atomic():
+            nodes = []
+            for pick in picks:
+                place = candidate_place_map[pick["place_id"]]
+                node, _ = GraphNode.objects.get_or_create(
+                    user=user,
+                    place=place,
+                    defaults={
+                        "status": "recommendation",
+                        "rationale": pick["rationale"][:255],
+                    },
+                )
+                nodes.append(node)
+
+        # Step 10 — log success.
+        LlmInteractionLog.objects.create(
+            user=user,
+            workflow="node_based_recommendation",
             prompt_version=prompt_version,
             embedding_model=embedder.model_name,
             language_model=llm.model_name,

--- a/ferv_project/recommendation/tests/test_node_based.py
+++ b/ferv_project/recommendation/tests/test_node_based.py
@@ -1,0 +1,395 @@
+"""
+Tests for Pipeline B — node-based recommendation.
+
+Mirrors test_exploratory.py: real DB writes for GraphNode / LlmInteractionLog,
+but EmbeddingService / Retriever / LlmClient and the embedding-vector lookup
+are patched so no external calls are made.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from django.urls import reverse
+
+from graph.models import GraphNode
+from places.models import Place
+from recommendation import recommendation_service, vector_utils
+from recommendation.models import LlmInteractionLog
+from recommendation.recommendation_service import RecommendationService
+
+
+# ── reciprocal_rank_fusion unit tests ────────────────────────────────────────
+
+class TestReciprocalRankFusion:
+    def test_empty_input(self):
+        assert vector_utils.reciprocal_rank_fusion([]) == []
+
+    def test_single_list_passthrough(self):
+        result = vector_utils.reciprocal_rank_fusion([["a", "b", "c"]], c=60)
+        assert [k for k, _ in result] == ["a", "b", "c"]
+        # Scores strictly decreasing.
+        scores = [s for _, s in result]
+        assert scores[0] > scores[1] > scores[2]
+
+    def test_overlap_boosts_rank(self):
+        # 'b' appears at rank 0 in list 2 and rank 1 in list 1; 'a' only at rank 0 in list 1.
+        result = vector_utils.reciprocal_rank_fusion(
+            [["a", "b"], ["b", "c"]], c=60
+        )
+        ranking = [k for k, _ in result]
+        assert ranking[0] == "b"  # appearing in both lists wins
+        assert set(ranking) == {"a", "b", "c"}
+
+    def test_known_scores(self):
+        # c=0 makes the math easy: 1/(rank+1).
+        result = vector_utils.reciprocal_rank_fusion(
+            [["a", "b"], ["b", "a"]], c=0
+        )
+        score_map = dict(result)
+        # a: 1/1 (list1 rank 0) + 1/2 (list2 rank 1) = 1.5
+        # b: 1/2 (list1 rank 1) + 1/1 (list2 rank 0) = 1.5
+        assert score_map["a"] == pytest.approx(1.5)
+        assert score_map["b"] == pytest.approx(1.5)
+
+    def test_duplicates_within_list_count_once(self):
+        result_dup = vector_utils.reciprocal_rank_fusion([["a", "a", "b"]], c=60)
+        result_no_dup = vector_utils.reciprocal_rank_fusion([["a", "b"]], c=60)
+        # Same item count and same first-rank score for 'a'.
+        assert dict(result_dup)["a"] == pytest.approx(dict(result_no_dup)["a"])
+
+    def test_deterministic_tiebreak_by_first_seen(self):
+        # Two completely disjoint lists, identical lengths → first-seen breaks ties.
+        result = vector_utils.reciprocal_rank_fusion(
+            [["a"], ["b"]], c=60
+        )
+        # 'a' was seen first.
+        assert [k for k, _ in result] == ["a", "b"]
+
+    def test_negative_c_rejected(self):
+        with pytest.raises(ValueError):
+            vector_utils.reciprocal_rank_fusion([["a"]], c=-1)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _make_place(idx: int) -> Place:
+    return Place.objects.create(
+        place_id=f"nb_place_{idx:03d}",
+        name=f"Place {idx}",
+        address=f"Calle {idx}",
+        neighborhood="Test",
+        latitude=6.25 + idx * 0.001,
+        longitude=-75.56,
+        rating=4.0,
+        price_level=2,
+        review_count=10,
+        editorial_summary=f"Summary {idx}",
+    )
+
+
+def _patch_pipeline_b(
+    monkeypatch,
+    *,
+    per_anchor_results: list[list[Place]],
+    llm_picks: list[dict],
+    n_override: int | None = None,
+):
+    """
+    Wire patches for EmbeddingService / Retriever / LlmClient / _anchor_vectors
+    so recommend_node_based runs without external calls or PlaceEmbedding rows.
+
+    `per_anchor_results[i]` is the candidate Place list returned for anchor i.
+    """
+    n = n_override if n_override is not None else len(llm_picks)
+    monkeypatch.setattr(recommendation_service, "NODE_BASED_N", n)
+    # Keep RRF fusion realistic but cap so all candidates flow through.
+    fused_candidate_count = sum(len(r) for r in per_anchor_results)
+    monkeypatch.setattr(
+        recommendation_service, "NODE_BASED_K",
+        max(fused_candidate_count, 1),
+    )
+
+    mock_embedder = MagicMock()
+    mock_embedder.model_name = "mock-embed-model"
+    mock_embedder.vector_class = MagicMock()  # only identity matters
+
+    mock_retriever = MagicMock()
+    call_log: list[dict] = []
+    iter_results = iter(per_anchor_results)
+
+    def get_candidates(query_vector, top_k, exclude_user=None):
+        try:
+            places = next(iter_results)
+        except StopIteration:
+            places = []
+        call_log.append(
+            {"top_k": top_k, "exclude_user": exclude_user, "n_places": len(places)}
+        )
+        return [{"place": p, "distance": 0.5} for p in places][:top_k]
+
+    mock_retriever.get_candidates.side_effect = get_candidates
+
+    mock_llm = MagicMock()
+    mock_llm.model_name = "mock-llm-model"
+    mock_llm.send.return_value = (
+        {"recommendations": llm_picks},
+        json.dumps({"recommendations": llm_picks}),
+    )
+
+    monkeypatch.setattr(
+        recommendation_service, "EmbeddingService", lambda *a, **kw: mock_embedder
+    )
+    monkeypatch.setattr(
+        recommendation_service, "Retriever", lambda *a, **kw: mock_retriever
+    )
+    monkeypatch.setattr(
+        recommendation_service, "LlmClient", lambda *a, **kw: mock_llm
+    )
+
+    # Bypass the real PlaceEmbedding lookup — return a dummy vector per anchor place.
+    def fake_anchor_vectors(places, vector_class):
+        return {p.pk: [0.1, 0.2, 0.3] for p in places}
+
+    monkeypatch.setattr(
+        recommendation_service, "_anchor_vectors", fake_anchor_vectors
+    )
+
+    return mock_embedder, mock_retriever, mock_llm, call_log
+
+
+def _make_anchor(user, place, status="in_graph"):
+    return GraphNode.objects.create(
+        user=user, place=place, status=status, rationale="seed"
+    )
+
+
+# ── Service tests ────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestRecommendNodeBased:
+
+    def test_happy_path_creates_nodes_and_logs(
+        self, monkeypatch, test_user_with_profile
+    ):
+        anchor_places = [_make_place(i) for i in range(3)]
+        anchors = [_make_anchor(test_user_with_profile, p) for p in anchor_places]
+        # 3 anchors → 3 disjoint candidate lists of 2 places each.
+        cand_places = [_make_place(100 + i) for i in range(6)]
+        per_anchor = [
+            [cand_places[0], cand_places[1]],
+            [cand_places[2], cand_places[3]],
+            [cand_places[4], cand_places[5]],
+        ]
+        picks = [
+            {"place_id": cand_places[0].place_id, "rationale": "extends quiet vibe"},
+            {"place_id": cand_places[2].place_id, "rationale": "matches taste"},
+        ]
+        _, _, _, call_log = _patch_pipeline_b(
+            monkeypatch,
+            per_anchor_results=per_anchor,
+            llm_picks=picks,
+        )
+
+        nodes = RecommendationService().recommend_node_based(
+            test_user_with_profile, [a.id for a in anchors]
+        )
+
+        assert len(nodes) == 2
+        assert {n.place.place_id for n in nodes} == {
+            cand_places[0].place_id, cand_places[2].place_id,
+        }
+        assert all(n.status == "recommendation" for n in nodes)
+
+        # 3 anchors → 3 retriever calls, all with exclude_user set.
+        assert len(call_log) == 3
+        assert all(c["exclude_user"] == test_user_with_profile for c in call_log)
+        assert all(c["top_k"] == recommendation_service.NODE_BASED_K_PRIME for c in call_log)
+
+        log = LlmInteractionLog.objects.latest()
+        assert log.workflow == "node_based_recommendation"
+        assert log.outcome == "success"
+        assert log.input_payload["anchor_node_ids"] == [a.id for a in anchors]
+        assert log.input_payload["anchor_place_ids"] == [p.place_id for p in anchor_places]
+        assert len(log.input_payload["per_anchor_retrieval"]) == 3
+        assert len(log.input_payload["fused_top_k"]) == 6  # all candidates fused
+
+    def test_rejects_picks_outside_fused_set(
+        self, monkeypatch, test_user_with_profile
+    ):
+        anchor_place = _make_place(0)
+        anchor = _make_anchor(test_user_with_profile, anchor_place)
+        cand_places = [_make_place(100 + i) for i in range(3)]
+        # Pick a place_id that was never in the fused candidate set.
+        rogue = _make_place(999)
+        picks = [{"place_id": rogue.place_id, "rationale": "should fail"}]
+        _patch_pipeline_b(
+            monkeypatch,
+            per_anchor_results=[cand_places],
+            llm_picks=picks,
+        )
+
+        with pytest.raises(ValueError, match="outside the fused candidate set"):
+            RecommendationService().recommend_node_based(
+                test_user_with_profile, [anchor.id]
+            )
+
+        # No new recommendation node was written.
+        assert GraphNode.objects.filter(
+            user=test_user_with_profile, status="recommendation"
+        ).count() == 0
+        log = LlmInteractionLog.objects.latest()
+        assert log.workflow == "node_based_recommendation"
+        assert log.outcome == "validation_error"
+
+    def test_empty_node_ids_raises_immediately(self, test_user_with_profile):
+        svc = RecommendationService()
+        logs_before = LlmInteractionLog.objects.count()
+        for bad in ([], None, "53", [1, "two"], [1, True]):
+            with pytest.raises(ValueError):
+                svc.recommend_node_based(test_user_with_profile, bad)  # type: ignore
+        assert LlmInteractionLog.objects.count() == logs_before
+
+    def test_anchor_not_owned_by_user_raises(
+        self, monkeypatch, test_user_with_profile
+    ):
+        # Anchor belongs to a different user.
+        from django.contrib.auth import get_user_model
+        other = get_user_model().objects.create_user(
+            username="other", email="other@x.com", password="x"
+        )
+        place = _make_place(0)
+        foreign_anchor = _make_anchor(other, place)
+
+        # Patch so we'd succeed if we got past validation — we shouldn't.
+        _patch_pipeline_b(
+            monkeypatch,
+            per_anchor_results=[[]],
+            llm_picks=[],
+        )
+
+        logs_before = LlmInteractionLog.objects.count()
+        with pytest.raises(ValueError, match="not owned by user"):
+            RecommendationService().recommend_node_based(
+                test_user_with_profile, [foreign_anchor.id]
+            )
+        assert LlmInteractionLog.objects.count() == logs_before
+
+    def test_anchor_with_recommendation_status_raises(
+        self, monkeypatch, test_user_with_profile
+    ):
+        place = _make_place(0)
+        wrong_status = _make_anchor(
+            test_user_with_profile, place, status="recommendation"
+        )
+
+        _patch_pipeline_b(
+            monkeypatch,
+            per_anchor_results=[[]],
+            llm_picks=[],
+        )
+
+        logs_before = LlmInteractionLog.objects.count()
+        with pytest.raises(ValueError, match="not in_graph"):
+            RecommendationService().recommend_node_based(
+                test_user_with_profile, [wrong_status.id]
+            )
+        assert LlmInteractionLog.objects.count() == logs_before
+
+    def test_anchor_without_embedding_raises_before_llm(
+        self, monkeypatch, test_user_with_profile
+    ):
+        from recommendation.models import GeminiEmbeddingVectorLarge
+
+        anchor_place = _make_place(0)
+        anchor = _make_anchor(test_user_with_profile, anchor_place)
+
+        # Don't patch _anchor_vectors — let the real one run against a real
+        # vector class. No PlaceEmbedding exists for this anchor in the test
+        # DB, so the service must raise before any LLM call.
+        mock_embedder = MagicMock()
+        mock_embedder.model_name = "mock-embed-model"
+        mock_embedder.vector_class = GeminiEmbeddingVectorLarge
+        mock_retriever = MagicMock()
+        mock_llm = MagicMock()
+        monkeypatch.setattr(
+            recommendation_service, "EmbeddingService",
+            lambda *a, **kw: mock_embedder,
+        )
+        monkeypatch.setattr(
+            recommendation_service, "Retriever", lambda *a, **kw: mock_retriever
+        )
+        monkeypatch.setattr(
+            recommendation_service, "LlmClient", lambda *a, **kw: mock_llm
+        )
+
+        logs_before = LlmInteractionLog.objects.count()
+        with pytest.raises(ValueError, match="without an embedding"):
+            RecommendationService().recommend_node_based(
+                test_user_with_profile, [anchor.id]
+            )
+        assert LlmInteractionLog.objects.count() == logs_before
+        mock_llm.send.assert_not_called()
+
+
+# ── View tests ───────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestNodeBasedEndpoint:
+
+    def test_requires_authentication(self, client):
+        from django.conf import settings
+        url = reverse("recommendation:node_based")
+        response = client.post(
+            url, data=json.dumps({"node_ids": [1]}), content_type="application/json"
+        )
+        assert response.status_code == 302
+        assert response.url.startswith(settings.LOGIN_URL)
+
+    def test_invalid_json(self, authenticated_client):
+        url = reverse("recommendation:node_based")
+        response = authenticated_client.post(
+            url, data="not json", content_type="application/json"
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize("payload", [
+        {},
+        {"node_ids": []},
+        {"node_ids": "53"},
+        {"node_ids": [1, "two"]},
+        {"node_ids": [1, True]},
+    ])
+    def test_rejects_bad_node_ids(self, authenticated_client, payload):
+        url = reverse("recommendation:node_based")
+        response = authenticated_client.post(
+            url, data=json.dumps(payload), content_type="application/json"
+        )
+        assert response.status_code == 400
+
+    def test_happy_path_endpoint(
+        self, monkeypatch, authenticated_client, test_user_with_profile
+    ):
+        anchor_places = [_make_place(i) for i in range(2)]
+        anchors = [_make_anchor(test_user_with_profile, p) for p in anchor_places]
+        cand_places = [_make_place(100 + i) for i in range(2)]
+        picks = [{"place_id": cand_places[0].place_id, "rationale": "fits"}]
+        _patch_pipeline_b(
+            monkeypatch,
+            per_anchor_results=[
+                [cand_places[0]],
+                [cand_places[1]],
+            ],
+            llm_picks=picks,
+        )
+
+        url = reverse("recommendation:node_based")
+        response = authenticated_client.post(
+            url,
+            data=json.dumps({"node_ids": [a.id for a in anchors]}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = json.loads(response.content)
+        assert len(body["nodes"]) == 1
+        assert body["nodes"][0]["place"]["place_id"] == cand_places[0].place_id

--- a/ferv_project/recommendation/urls.py
+++ b/ferv_project/recommendation/urls.py
@@ -6,5 +6,6 @@ app_name = 'recommendation'
 
 urlpatterns = [
     path('recommend/', views.recommend, name='recommend'),
+    path('node_based/', views.node_based_recommend, name='node_based'),
     path('exploratory/', views.exploratory_recommend, name='exploratory'),
 ]

--- a/ferv_project/recommendation/vector_utils.py
+++ b/ferv_project/recommendation/vector_utils.py
@@ -1,13 +1,14 @@
 """
 vector_utils.py
 ---------------
-Pure-Python vector helpers for the exploratory recommendation pipeline.
+Pure-Python vector helpers for the recommendation pipelines.
 No numpy dependency. Functions are side-effect free; the RNG is injectable
 so callers (and tests) can pin determinism.
 """
 
 import math
 import random
+from typing import Hashable, Sequence
 
 
 def random_unit_vector(dim: int, rng: random.Random | None = None) -> list[float]:
@@ -35,3 +36,45 @@ def vector_add_scaled(
             f"length mismatch: base={len(base)}, direction={len(direction)}"
         )
     return [b + scalar * d for b, d in zip(base, direction)]
+
+
+def reciprocal_rank_fusion(
+    ranked_lists: Sequence[Sequence[Hashable]], c: int = 60
+) -> list[tuple[Hashable, float]]:
+    """
+    Reciprocal Rank Fusion across n ranked lists of opaque IDs.
+
+    For each list, an item at zero-based rank r contributes 1 / (c + r + 1)
+    to its total score. The +1 makes the first item contribute 1/(c+1) — the
+    standard Cormack/Buettcher/Clarke formulation — and the +1 inside guards
+    against c=0 collapsing the top item to a divide-by-zero.
+
+    Returns (id, score) pairs sorted by score descending. Ties are broken by
+    earliest first-appearance across the input lists, then by lexicographic
+    order on the id, so the output is deterministic.
+
+    Empty input → []. Lists may overlap, may be empty, and may have different
+    lengths. Items repeated within a single list count only at their first
+    occurrence in that list.
+    """
+    if c < 0:
+        raise ValueError(f"c must be non-negative, got {c}")
+
+    scores: dict[Hashable, float] = {}
+    first_seen: dict[Hashable, int] = {}
+    seq = 0
+    for ranked in ranked_lists:
+        seen_in_list: set[Hashable] = set()
+        for rank, item in enumerate(ranked):
+            if item in seen_in_list:
+                continue
+            seen_in_list.add(item)
+            scores[item] = scores.get(item, 0.0) + 1.0 / (c + rank + 1)
+            if item not in first_seen:
+                first_seen[item] = seq
+                seq += 1
+
+    return sorted(
+        scores.items(),
+        key=lambda kv: (-kv[1], first_seen[kv[0]], str(kv[0])),
+    )

--- a/ferv_project/recommendation/views.py
+++ b/ferv_project/recommendation/views.py
@@ -2,6 +2,7 @@
 views.py
 --------
 POST /api/recommendation/recommend/    → Pipeline A: one-shot recommendation
+POST /api/recommendation/node_based/   → Pipeline B: node-based recommendation
 POST /api/recommendation/exploratory/  → Pipeline C: exploratory recommendation
 """
 
@@ -60,6 +61,41 @@ def recommend(request):
         return JsonResponse({"error": str(e)}, status=500)
     except Exception as e:
         log.error("recommend view unexpected error: %s", e)
+        return JsonResponse({"error": "Internal server error."}, status=500)
+
+
+@login_required
+@require_POST
+def node_based_recommend(request):
+    """
+    POST /api/recommendation/node_based/
+    Body JSON: { "node_ids": [<int>, ...] }
+
+    Runs Pipeline B for the authenticated user, seeded by their existing
+    in_graph GraphNode IDs. Returns up to N new recommendation nodes.
+    """
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, AttributeError):
+        return JsonResponse({"error": "Invalid JSON."}, status=400)
+
+    node_ids = body.get("node_ids")
+    if not node_ids:
+        return JsonResponse({"error": "node_ids is required."}, status=400)
+    if not isinstance(node_ids, list):
+        return JsonResponse({"error": "node_ids must be a list."}, status=400)
+    if not all(isinstance(nid, int) and not isinstance(nid, bool) for nid in node_ids):
+        return JsonResponse({"error": "node_ids must contain only integers."}, status=400)
+
+    try:
+        from recommendation.recommendation_service import RecommendationService
+        nodes = RecommendationService().recommend_node_based(request.user, node_ids)
+        return JsonResponse({"nodes": [_serialize_node(n) for n in nodes]})
+    except ValueError as e:
+        log.error("node_based_recommend view error: %s", e)
+        return JsonResponse({"error": str(e)}, status=500)
+    except Exception as e:
+        log.error("node_based_recommend view unexpected error: %s", e)
         return JsonResponse({"error": "Internal server error."}, status=500)
 
 


### PR DESCRIPTION
Implements the third recommendation pipeline specified in docs/recommendation_pipelines.md §2: given a list of the user's existing in_graph GraphNode IDs, run one similarity query per anchor, fuse the ranked lists with Reciprocal Rank Fusion, and ask the LLM to pick N candidates that extend the pattern.

- vector_utils.reciprocal_rank_fusion (pure helper, deterministic tie-break).
- RecommendationService.recommend_node_based + _anchor_vectors helper.
- node_based_recommendation_v1.txt prompt (uses anchors_block, no prompt_text slot).
- POST /api/recommendation/node_based/ view + URL.
- 21 tests (RRF unit + service + endpoint), all using LlmInteractionLog.objects.latest() to avoid MultipleObjectsReturned when multiple log rows share a workflow.
- HTTP-surface section of docs/recommendation_system_architecture.md updated to list all three pipelines.